### PR TITLE
feat: Add options.jsonParser and options.jsonStringifier

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -10,6 +10,7 @@ function Parser (options) {
   Transform.call(this, { objectMode: true })
   this._memory = ''
   this._emitInvalidLines = (options.emitInvalidLines || false)
+  this._jsonParser = (options.jsonParser || JSON.parse)
 }
 
 Parser.prototype = Object.create(Transform.prototype)
@@ -21,7 +22,7 @@ Parser.prototype._handleLines = function (lines, cb) {
     var err = null
     var json = null
     try {
-      json = JSON.parse(lines[i])
+      json = this._jsonParser(lines[i])
     } catch (_err) {
       _err.source = lines[i]
       err = _err

--- a/lib/stringifier.js
+++ b/lib/stringifier.js
@@ -1,11 +1,14 @@
 var Transform = require('stream').Transform
 
-function Stringifier () {
+function Stringifier (options) {
   if (!(this instanceof Stringifier)) {
     throw new TypeError('Cannot call a class as a function')
   }
 
+  options = options || {}
+
   Transform.call(this, { objectMode: true })
+  this._jsonStringifier = (options.jsonStringifier || JSON.stringify)
 }
 
 Stringifier.prototype = Object.create(Transform.prototype)
@@ -14,7 +17,7 @@ Stringifier.prototype._transform = function (data, _, cb) {
   var value
 
   try {
-    value = JSON.stringify(data)
+    value = this._jsonStringifier(data)
   } catch (err) {
     err.source = data
     return cb(err)

--- a/test/parser.js
+++ b/test/parser.js
@@ -112,4 +112,20 @@ describe('Parser', function () {
 
     parser.end(data)
   })
+
+  it('should accept custom jsonParser', function (done) {
+    var parser = jsonlines.parse({
+      jsonParser: function (line) {
+        assert.equal(line, 'true')
+        return true
+      }
+    })
+
+    parser.once('data', function (data) {
+      assert.equal(data, true)
+      done()
+    })
+
+    parser.end('true')
+  })
 })

--- a/test/stringifier.js
+++ b/test/stringifier.js
@@ -60,4 +60,20 @@ describe('Stringifier', function () {
 
     stringifier.end(broken)
   })
+
+  it('should accept custom jsonParser', function (done) {
+    var stringifier = jsonlines.stringify({
+      jsonStringifier: function (line) {
+        assert.equal(line, true)
+        return 'true'
+      }
+    })
+
+    stringifier.once('data', function (data) {
+      assert.equal(data, 'true\n')
+      done()
+    })
+
+    stringifier.end(true)
+  })
 })


### PR DESCRIPTION
This allows people to use `node-jsonlines` with supersets of JSON such as JSONC (json with comments), JSON5 (json for humans), etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linusu/node-jsonlines/3)
<!-- Reviewable:end -->
